### PR TITLE
Simplify derived state

### DIFF
--- a/modules/react/src/components/export-video/constants.js
+++ b/modules/react/src/components/export-video/constants.js
@@ -24,50 +24,64 @@ export const DEFAULT_BUTTON_WIDTH = '64px';
 export const DEFAULT_PADDING = '32px';
 export const DEFAULT_ROW_GAP = '16px';
 
-export const GOOD_16_9 = {
-  label: 'Good 16:9 (540p)',
-  width: 960,
-  height: 540
-};
-export const HIGH_16_9 = {
-  label: 'High 16:9 (720p)',
-  width: 1280,
-  height: 720
-};
-export const HIGHEST_16_9 = {
-  label: 'Highest 16:9 (1080p)',
-  width: 1920,
-  height: 1080
-};
-export const GOOD_4_3 = {
-  label: 'Good 4:3 (480p)',
-  width: 640,
-  height: 480
-};
-export const HIGH_4_3 = {
-  label: 'High 4:3 (960p)',
-  width: 1280,
-  height: 960
-};
-export const HIGHEST_4_3 = {
-  label: 'Highest 4:3 (1440p)',
-  width: 1920,
-  height: 1440
-};
-
-export function getQualitySettings(label) {
-  if (label === 'Good 16:9 (540p)') {
-    return GOOD_16_9;
-  } else if (label === 'High 16:9 (720p)') {
-    return HIGH_16_9;
-  } else if (label === 'Highest 16:9 (1080p)') {
-    return HIGHEST_16_9;
-  } else if (label === 'Good 4:3 (480p)') {
-    return GOOD_4_3;
-  } else if (label === 'High 4:3 (960p)') {
-    return HIGH_4_3;
-  } else if (label === 'Highest 4:3 (1440p)') {
-    return HIGHEST_4_3;
+export const FORMATS = [
+  {
+    value: 'gif',
+    label: 'GIF'
+  },
+  {
+    value: 'webm',
+    label: 'WebM Video'
+  },
+  {
+    value: 'png',
+    label: 'PNG Sequence'
+  },
+  {
+    value: 'jpeg',
+    label: 'JPEG Sequence'
   }
-  throw new Error(`Unsupported Quality Settings label: ${label}`);
+];
+
+export const RESOLUTIONS = [
+  {
+    value: 0,
+    label: 'Good 16:9 (540p)',
+    width: 960,
+    height: 540
+  },
+  {
+    value: 1,
+    label: 'High 16:9 (720p)',
+    width: 1280,
+    height: 720
+  },
+  {
+    value: 2,
+    label: 'Highest 16:9 (1080p)',
+    width: 1920,
+    height: 1080
+  },
+  {
+    value: 3,
+    label: 'Good 4:3 (480p)',
+    width: 640,
+    height: 480
+  },
+  {
+    value: 4,
+    label: 'High 4:3 (960p)',
+    width: 1280,
+    height: 960
+  },
+  {
+    value: 5,
+    label: 'Highest 4:3 (1440p)',
+    width: 1920,
+    height: 1440
+  }
+];
+
+export function getResolutionSetting(index) {
+  return RESOLUTIONS[index] || RESOLUTIONS[0];
 }

--- a/modules/react/src/components/export-video/export-video-panel-settings.js
+++ b/modules/react/src/components/export-video/export-video-panel-settings.js
@@ -22,16 +22,7 @@ import React from 'react';
 import {Input, ItemSelector, Slider} from 'kepler.gl/components';
 import styled, {withTheme} from 'styled-components';
 
-import {
-  DEFAULT_PADDING,
-  DEFAULT_ROW_GAP,
-  GOOD_16_9,
-  GOOD_4_3,
-  HIGHEST_16_9,
-  HIGHEST_4_3,
-  HIGH_16_9,
-  HIGH_4_3
-} from './constants';
+import {DEFAULT_PADDING, DEFAULT_ROW_GAP, FORMATS, RESOLUTIONS} from './constants';
 
 import {msConversion, estimateFileSize} from './utils';
 
@@ -77,11 +68,18 @@ const InputGrid = styled.div`
   grid-row-gap: ${DEFAULT_ROW_GAP};
 `;
 
+const getOptionValue = r => r.value;
+const displayOption = r => r.label;
+const getSelectedItems = (options, value) => {
+  const item = options.find(o => o.value === value);
+  return item ? [item] : [];
+};
+
 const ExportVideoPanelSettings = ({
   setMediaType,
   setCameraPreset,
   setFileName,
-  setQuality,
+  setResolution,
   settingsData,
   durationMs,
   frameRate,
@@ -127,26 +125,23 @@ const ExportVideoPanelSettings = ({
       <Input placeholder={settingsData.fileName} onChange={setFileName} />
       <StyledLabelCell>Media Type</StyledLabelCell>
       <ItemSelector
-        selectedItems={settingsData.mediaType}
-        options={['GIF', 'WebM Video', 'PNG Sequence', 'JPEG Sequence']}
+        selectedItems={getSelectedItems(FORMATS, settingsData.mediaType)}
+        options={FORMATS}
+        getOptionValue={getOptionValue}
+        displayOption={displayOption}
         multiSelect={false}
         searchable={false}
         onChange={setMediaType}
       />
-      <StyledLabelCell>Quality</StyledLabelCell>
+      <StyledLabelCell>Resolution</StyledLabelCell>
       <ItemSelector
-        selectedItems={settingsData.resolution}
-        options={[
-          GOOD_16_9.label,
-          HIGH_16_9.label,
-          HIGHEST_16_9.label,
-          GOOD_4_3.label,
-          HIGH_4_3.label,
-          HIGHEST_4_3.label
-        ]}
+        selectedItems={getSelectedItems(RESOLUTIONS, settingsData.resolution)}
+        options={RESOLUTIONS}
+        getOptionValue={getOptionValue}
+        displayOption={displayOption}
         multiSelect={false}
         searchable={false}
-        onChange={setQuality}
+        onChange={setResolution}
       />
     </InputGrid>
     <InputGrid style={{marginTop: DEFAULT_ROW_GAP}} rows={2} rowHeight="18px">

--- a/modules/react/src/components/export-video/export-video-panel.js
+++ b/modules/react/src/components/export-video/export-video-panel.js
@@ -74,7 +74,7 @@ const PanelBody = ({
   setMediaType,
   setCameraPreset,
   setFileName,
-  setQuality,
+  setResolution,
   settingsData,
   durationMs,
   frameRate,
@@ -95,7 +95,7 @@ const PanelBody = ({
       setMediaType={setMediaType}
       setCameraPreset={setCameraPreset}
       setFileName={setFileName}
-      setQuality={setQuality}
+      setResolution={setResolution}
       settingsData={settingsData}
       durationMs={durationMs}
       frameRate={frameRate}
@@ -119,10 +119,10 @@ const ExportVideoPanel = ({
   setViewState,
   // Settings Props
   settingsData,
-  setMediaTypeState,
+  setMediaType,
   setCameraPreset,
   setFileName,
-  setQuality,
+  setResolution,
   // Hubble Props
   adapter,
   handlePreviewVideo,
@@ -142,10 +142,10 @@ const ExportVideoPanel = ({
         <PanelBody
           mapData={mapData}
           adapter={adapter}
-          setMediaType={setMediaTypeState}
+          setMediaType={setMediaType}
           setCameraPreset={setCameraPreset}
           setFileName={setFileName}
-          setQuality={setQuality}
+          setResolution={setResolution}
           settingsData={settingsData}
           setViewState={setViewState}
           durationMs={durationMs}


### PR DESCRIPTION
**Summary**
- Simplify ExportVideoPanelContainer derived state
- Derive encoderSettings and canvasWidth/Height during render
- Use `<ItemSelector>` with const options and accessors
- Rename `quality` to `resolution`

The logic in ExportVideoPanelContainer gets hairy because its `this.state` includes both source-of-truth data (like `quality`) and derived data (like `canvasWidth` and `encoderSettings`).

A more react-like solution is to only store the source data in the state, and derive `encoderSettings` and `canvasWidth` on the fly during rendering. This can cause some redundant computation but ensures derived state is always up to date.

The format of `qualitySettings` being the human-readable label will break if localized to another language. A better way is to use `<ItemSelector>` as intended, and provide it with a list of option objects, as well as accessors for the label and value (`(option) => option.label`). I applied this to both the encoding format and the resolution selector.

The word `quality` is used for both resolution and encoding quality, leading to some confusing prop chains. I standardized it so that `resolution` refers to `width/height` and quality can be used for encoder quality instead.
